### PR TITLE
Fix detection of LXC v1

### DIFF
--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -64,7 +64,7 @@ class Connection(ConnectionBase):
             self.lxc_version = 2
             display.vvv('LXC v2')
         elif (returncode1 == 0):
-            self.lxc_version = 2
+            self.lxc_version = 1
             display.vvv('LXC v1')
         else:
             raise AnsibleConnectionFailure('Cannot identify LXC version')


### PR DESCRIPTION
The lxc_version variable is incorrectly set to 2 even if version 1 was detected. Here's a tiny fix.