### PR TITLE
use login shell with lxc-attach

### DIFF
--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -1128,7 +1128,7 @@ class Connection(ConnectionBase):
                     % (pipes.quote(h),
                        pipes.quote(cmd))
         elif (self.lxc_version == 1):
-            lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
+            lxc_cmd = 'lxc-attach --name %s -- /bin/sh -l -c %s'  \
                     % (pipes.quote(h),
                        pipes.quote(cmd))
         if in_data:
@@ -1171,7 +1171,7 @@ class Connection(ConnectionBase):
                         % (pipes.quote(h),
                            pipes.quote(cmd))
             elif (self.lxc_version == 1):
-                lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
+                lxc_cmd = 'lxc-attach --name %s -- /bin/sh -l -c %s'  \
                         % (pipes.quote(h),
                            pipes.quote(cmd))
             if in_data:
@@ -1208,7 +1208,7 @@ class Connection(ConnectionBase):
                     % (pipes.quote(h),
                        pipes.quote(cmd))
         elif (self.lxc_version == 1):
-            lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
+            lxc_cmd = 'lxc-attach --name %s -- /bin/sh -l -c %s'  \
                     % (pipes.quote(h),
                        pipes.quote(cmd))
 


### PR DESCRIPTION
Makes ```lxc-attach``` use a login shell via ```sh -l``` in order to have the environment being properly set up (e.g. ```$PATH``` contains ```/usr/sbin```).