### PR TITLE
fix python3 compatibility

### DIFF
--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -226,7 +226,7 @@ class Connection(ConnectionBase):
         list ['-o', 'Foo=1', '-o', 'Bar=foo bar'] that can be added to
         the argument list. The list will not contain any empty elements.
         """
-        return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
+        return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring).decode()) if x.strip()]
 
 
     if LooseVersion(ansible_version) < LooseVersion('2.3.0.0'):
@@ -556,7 +556,7 @@ class Connection(ConnectionBase):
         if isinstance(cmd, (text_type, binary_type)):
             cmd = to_bytes(cmd)
         else:
-            cmd = map(to_bytes, cmd)
+            cmd = list(map(to_bytes, cmd))
 
         if not in_data:
             try:


### PR DESCRIPTION
testet on

python 3.5.3:
 * ansible 2.7.1

python 2.7.13
* ansible 2.7.7

I'm not sure about python2 compatibility but it looks like it works.