### PR TITLE
refactored with black, for PEP8

### DIFF
--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -20,10 +20,11 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
     name: lxc_ssh
     short_description: connect via ssh and lxc to remote lxc guest
     description:
@@ -349,7 +350,7 @@ DOCUMENTATION = '''
           - name: lxc_host
         cli:
           - name: lxc_host
-'''
+"""
 
 import errno
 import fcntl
@@ -375,18 +376,24 @@ from ansible.module_utils.parsing.convert_bool import BOOLEANS, boolean
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.path import unfrackpath, makedirs_safe
 
-from ansible.module_utils._text import to_bytes, to_text as to_unicode, to_native as to_str
+from ansible.module_utils._text import (
+    to_bytes,
+    to_text as to_unicode,
+    to_native as to_str,
+)
 
 try:
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
+
     display = Display()
 
 
 # only used from Ansible version 2.3 on forward
 class AnsibleControlPersistBrokenPipeError(AnsibleError):
-    ''' ControlPersist broken pipe '''
+    """ControlPersist broken pipe"""
+
     pass
 
 
@@ -401,16 +408,21 @@ def _ssh_retry(func):
     * remaining_tries is <2
     * retries limit reached
     """
+
     @wraps(func)
     def wrapped(self, *args, **kwargs):
-        remaining_tries = int(self.get_option('retries')) + 1
+        remaining_tries = int(self.get_option("retries")) + 1
         cmd_summary = "%s..." % args[0]
         for attempt in range(remaining_tries):
             cmd = args[0]
             if attempt != 0 and self._play_context.password and isinstance(cmd, list):
                 # If this is a retry, the fd/pipe for sshpass is closed, and we need a new one
                 self.sshpass_pipe = os.pipe()
-                cmd[1] = b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict')
+                cmd[1] = b"-d" + to_bytes(
+                    self.sshpass_pipe[0],
+                    nonstring="simplerepr",
+                    errors="surrogate_or_strict",
+                )
 
             try:
                 try:
@@ -427,7 +439,10 @@ def _ssh_retry(func):
                 if return_tuple[0] != 255:
                     break
                 else:
-                    raise AnsibleConnectionFailure("Failed to connect to the host via ssh: %s" % to_native(return_tuple[2]))
+                    raise AnsibleConnectionFailure(
+                        "Failed to connect to the host via ssh: %s"
+                        % to_native(return_tuple[2])
+                    )
             except (AnsibleConnectionFailure, Exception) as e:
                 if attempt == remaining_tries - 1:
                     raise
@@ -437,9 +452,15 @@ def _ssh_retry(func):
                         pause = 30
 
                     if isinstance(e, AnsibleConnectionFailure):
-                        msg = "ssh_retry: attempt: %d, ssh return code is 255. cmd (%s), pausing for %d seconds" % (attempt, cmd_summary, pause)
+                        msg = (
+                            "ssh_retry: attempt: %d, ssh return code is 255. cmd (%s), pausing for %d seconds"
+                            % (attempt, cmd_summary, pause)
+                        )
                     else:
-                        msg = "ssh_retry: attempt: %d, caught exception(%s) from cmd (%s), pausing for %d seconds" % (attempt, e, cmd_summary, pause)
+                        msg = (
+                            "ssh_retry: attempt: %d, caught exception(%s) from cmd (%s), pausing for %d seconds"
+                            % (attempt, e, cmd_summary, pause)
+                        )
 
                     display.vv(msg, host=self.host)
 
@@ -447,16 +468,18 @@ def _ssh_retry(func):
                     continue
 
         return return_tuple
+
     return wrapped
 
 
 class Connection(ConnectionBase):
-    ''' ssh+lxc_attach connection '''
-    transport = 'lxc_ssh'
+    """ssh+lxc_attach connection"""
+
+    transport = "lxc_ssh"
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
-        #print args
-        #print kwargs
+        # print args
+        # print kwargs
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
         self.host = self._play_context.remote_addr
         self.port = self._play_context.port
@@ -468,61 +491,60 @@ class Connection(ConnectionBase):
         # LXC v1 uses 'lxc-info', 'lxc-attach' and so on
         # LXC v2 uses just 'lxc'
         (returncode2, stdout2, stderr2) = self._exec_command("which lxc", None, False)
-        (returncode1, stdout1, stderr1) = self._exec_command("which lxc-info", None, False)
-        if (returncode2 == 0):
+        (returncode1, stdout1, stderr1) = self._exec_command(
+            "which lxc-info", None, False
+        )
+        if returncode2 == 0:
             self.lxc_version = 2
-            display.vvv('LXC v2')
-        elif (returncode1 == 0):
+            display.vvv("LXC v2")
+        elif returncode1 == 0:
             self.lxc_version = 1
-            display.vvv('LXC v1')
+            display.vvv("LXC v1")
         else:
-            raise AnsibleConnectionFailure('Cannot identify LXC version')
+            raise AnsibleConnectionFailure("Cannot identify LXC version")
             sys.exit(1)
-
 
     # The connection is created by running ssh/scp/sftp from the exec_command,
     # put_file, and fetch_file methods, so we don't need to do any connection
     # management here.
     def _connect(self):
-        ''' connect to the lxc; nothing to do here '''
-        display.vvv('XXX connect')
+        """connect to the lxc; nothing to do here"""
+        display.vvv("XXX connect")
         super(Connection, self)._connect()
-        self.container_name = self.get_option('lxc_host')
+        self.container_name = self.get_option("lxc_host")
 
     # only used from Ansible version 2.3 on forward
     @staticmethod
     def _create_control_path(host, port, user, connection=None):
-        '''Make a hash for the controlpath based on con attributes'''
-        pstring = '%s-%s-%s' % (host, port, user)
+        """Make a hash for the controlpath based on con attributes"""
+        pstring = "%s-%s-%s" % (host, port, user)
         if connection:
-            pstring += '-%s' % connection
+            pstring += "-%s" % connection
         m = hashlib.sha1()
         m.update(to_bytes(pstring))
         digest = m.hexdigest()
-        cpath = '%(directory)s/' + digest[:10]
+        cpath = "%(directory)s/" + digest[:10]
         return cpath
-
 
     @staticmethod
     def _persistence_controls(b_command):
-        '''
+        """
         Takes a command array and scans it for ControlPersist and ControlPath
         settings and returns two booleans indicating whether either was found.
         This could be smarter, e.g. returning false if ControlPersist is 'no',
         but for now we do it simple way.
-        '''
+        """
 
         controlpersist = False
         controlpath = False
 
         for b_arg in (a.lower() for a in b_command):
-            if b'controlpersist' in b_arg:
+            if b"controlpersist" in b_arg:
                 controlpersist = True
-            elif b'controlpath' in b_arg:
+            elif b"controlpath" in b_arg:
                 controlpath = True
 
         return controlpersist, controlpath
-
 
     @staticmethod
     def _split_args(argstring):
@@ -532,10 +554,17 @@ class Connection(ConnectionBase):
         the argument list. The list will not contain any empty elements.
         """
         if sys.version_info[0] >= 3:
-            return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring).decode()) if x.strip()]
+            return [
+                to_unicode(x.strip())
+                for x in shlex.split(to_bytes(argstring).decode())
+                if x.strip()
+            ]
         else:
-            return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
-
+            return [
+                to_unicode(x.strip())
+                for x in shlex.split(to_bytes(argstring))
+                if x.strip()
+            ]
 
     def _add_args(self, b_command, b_args, explanation):
         """
@@ -549,11 +578,14 @@ class Connection(ConnectionBase):
             were added.  It will be displayed with a high enough verbosity.
         .. note:: This function does its work via side-effect.  The b_command list has the new arguments appended.
         """
-        display.vvvvv(u'SSH: %s: (%s)' % (explanation, ')('.join(to_text(a) for a in b_args)), host=self._play_context.remote_addr)
+        display.vvvvv(
+            u"SSH: %s: (%s)" % (explanation, ")(".join(to_text(a) for a in b_args)),
+            host=self._play_context.remote_addr,
+        )
         b_command += b_args
 
     def _build_command(self, binary, subsystem, *other_args):
-        '''
+        """
         Takes a executable (ssh, scp, sftp or wrapper) and optional extra arguments and returns the remote command
         wrapped in local ssh shell commands and ready for execution.
 
@@ -561,10 +593,10 @@ class Connection(ConnectionBase):
         :arg subsystem: type of executable provided, ssh/sftp/scp, needed because wrappers for ssh might have diff names.
         :arg other_args: dict of, value pairs passed as arguments to the ssh binary
 
-        '''
+        """
 
         b_command = []
-        conn_password = self.get_option('password') or self._play_context.password
+        conn_password = self.get_option("password") or self._play_context.password
 
         #
         # First, the command to invoke
@@ -575,16 +607,29 @@ class Connection(ConnectionBase):
 
         if conn_password:
             if not self._sshpass_available():
-                raise AnsibleError("to use the 'ssh' connection type with passwords, you must install the sshpass program")
+                raise AnsibleError(
+                    "to use the 'ssh' connection type with passwords, you must install the sshpass program"
+                )
 
             self.sshpass_pipe = os.pipe()
-            b_command += [b'sshpass', b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict')]
+            b_command += [
+                b"sshpass",
+                b"-d"
+                + to_bytes(
+                    self.sshpass_pipe[0],
+                    nonstring="simplerepr",
+                    errors="surrogate_or_strict",
+                ),
+            ]
 
-            password_prompt = self.get_option('sshpass_prompt')
+            password_prompt = self.get_option("sshpass_prompt")
             if password_prompt:
-                b_command += [b'-P', to_bytes(password_prompt, errors='surrogate_or_strict')]
+                b_command += [
+                    b"-P",
+                    to_bytes(password_prompt, errors="surrogate_or_strict"),
+                ]
 
-        b_command += [to_bytes(binary, errors='surrogate_or_strict')]
+        b_command += [to_bytes(binary, errors="surrogate_or_strict")]
 
         #
         # Next, additional arguments based on the configuration.
@@ -594,69 +639,108 @@ class Connection(ConnectionBase):
         # be disabled if the client side doesn't support the option. However,
         # sftp batch mode does not prompt for passwords so it must be disabled
         # if not using controlpersist and using sshpass
-        if subsystem == 'sftp' and self.get_option('sftp_batch_mode'):
+        if subsystem == "sftp" and self.get_option("sftp_batch_mode"):
             if conn_password:
-                b_args = [b'-o', b'BatchMode=no']
-                self._add_args(b_command, b_args, u'disable batch mode for sshpass')
-            b_command += [b'-b', b'-']
+                b_args = [b"-o", b"BatchMode=no"]
+                self._add_args(b_command, b_args, u"disable batch mode for sshpass")
+            b_command += [b"-b", b"-"]
 
         if self._play_context.verbosity > 3:
-            b_command.append(b'-vvv')
+            b_command.append(b"-vvv")
 
         # Next, we add ssh_args
-        ssh_args = self.get_option('ssh_args')
+        ssh_args = self.get_option("ssh_args")
         if ssh_args:
-            b_args = [to_bytes(a, errors='surrogate_or_strict') for a in
-                      self._split_ssh_args(ssh_args)]
+            b_args = [
+                to_bytes(a, errors="surrogate_or_strict")
+                for a in self._split_ssh_args(ssh_args)
+            ]
             self._add_args(b_command, b_args, u"ansible.cfg set ssh_args")
 
         # Now we add various arguments that have their own specific settings defined in docs above.
-        if not self.get_option('host_key_checking'):
+        if not self.get_option("host_key_checking"):
             b_args = (b"-o", b"StrictHostKeyChecking=no")
-            self._add_args(b_command, b_args, u"ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled")
+            self._add_args(
+                b_command,
+                b_args,
+                u"ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled",
+            )
 
-        self.port = self.get_option('port')
+        self.port = self.get_option("port")
         if self.port is not None:
-            b_args = (b"-o", b"Port=" + to_bytes(self.port, nonstring='simplerepr', errors='surrogate_or_strict'))
-            self._add_args(b_command, b_args, u"ANSIBLE_REMOTE_PORT/remote_port/ansible_port set")
+            b_args = (
+                b"-o",
+                b"Port="
+                + to_bytes(
+                    self.port, nonstring="simplerepr", errors="surrogate_or_strict"
+                ),
+            )
+            self._add_args(
+                b_command, b_args, u"ANSIBLE_REMOTE_PORT/remote_port/ansible_port set"
+            )
 
-        key = self.get_option('private_key_file')
+        key = self.get_option("private_key_file")
         if key:
-            b_args = (b"-o", b'IdentityFile="' + to_bytes(os.path.expanduser(key), errors='surrogate_or_strict') + b'"')
-            self._add_args(b_command, b_args, u"ANSIBLE_PRIVATE_KEY_FILE/private_key_file/ansible_ssh_private_key_file set")
+            b_args = (
+                b"-o",
+                b'IdentityFile="'
+                + to_bytes(os.path.expanduser(key), errors="surrogate_or_strict")
+                + b'"',
+            )
+            self._add_args(
+                b_command,
+                b_args,
+                u"ANSIBLE_PRIVATE_KEY_FILE/private_key_file/ansible_ssh_private_key_file set",
+            )
 
         if not conn_password:
             self._add_args(
-                b_command, (
-                    b"-o", b"KbdInteractiveAuthentication=no",
-                    b"-o", b"PreferredAuthentications=publickey,gssapi-with-mic,gssapi-keyex,hostbased",
-                    b"-o", b"PasswordAuthentication=no"
+                b_command,
+                (
+                    b"-o",
+                    b"KbdInteractiveAuthentication=no",
+                    b"-o",
+                    b"PreferredAuthentications=publickey,gssapi-with-mic,gssapi-keyex,hostbased",
+                    b"-o",
+                    b"PasswordAuthentication=no",
                 ),
-                u"ansible_password/ansible_ssh_password not set"
+                u"ansible_password/ansible_ssh_password not set",
             )
 
-        self.user = self.get_option('remote_user')
+        self.user = self.get_option("remote_user")
         if self.user:
             self._add_args(
                 b_command,
-                (b"-o", b'User="%s"' % to_bytes(self.user, errors='surrogate_or_strict')),
-                u"ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set"
+                (
+                    b"-o",
+                    b'User="%s"' % to_bytes(self.user, errors="surrogate_or_strict"),
+                ),
+                u"ANSIBLE_REMOTE_USER/remote_user/ansible_user/user/-u set",
             )
 
-        timeout = self.get_option('timeout')
+        timeout = self.get_option("timeout")
         self._add_args(
             b_command,
-            (b"-o", b"ConnectTimeout=" + to_bytes(timeout, errors='surrogate_or_strict', nonstring='simplerepr')),
-            u"ANSIBLE_TIMEOUT/timeout set"
+            (
+                b"-o",
+                b"ConnectTimeout="
+                + to_bytes(
+                    timeout, errors="surrogate_or_strict", nonstring="simplerepr"
+                ),
+            ),
+            u"ANSIBLE_TIMEOUT/timeout set",
         )
 
         # Add in any common or binary-specific arguments from the PlayContext
         # (i.e. inventory or task settings or overrides on the command line).
 
-        for opt in (u'ssh_common_args', u'{0}_extra_args'.format(subsystem)):
+        for opt in (u"ssh_common_args", u"{0}_extra_args".format(subsystem)):
             attr = self.get_option(opt)
             if attr is not None:
-                b_args = [to_bytes(a, errors='surrogate_or_strict') for a in self._split_ssh_args(attr)]
+                b_args = [
+                    to_bytes(a, errors="surrogate_or_strict")
+                    for a in self._split_ssh_args(attr)
+                ]
                 self._add_args(b_command, b_args, u"Set %s" % opt)
 
         # Check if ControlPersist is enabled and add a ControlPath if one hasn't
@@ -668,24 +752,33 @@ class Connection(ConnectionBase):
             self._persistent = True
 
             if not controlpath:
-                self.control_path_dir = self.get_option('control_path_dir')
+                self.control_path_dir = self.get_option("control_path_dir")
                 cpdir = unfrackpath(self.control_path_dir)
-                b_cpdir = to_bytes(cpdir, errors='surrogate_or_strict')
+                b_cpdir = to_bytes(cpdir, errors="surrogate_or_strict")
 
                 # The directory must exist and be writable.
                 makedirs_safe(b_cpdir, 0o700)
                 if not os.access(b_cpdir, os.W_OK):
-                    raise AnsibleError("Cannot write to ControlPath %s" % to_native(cpdir))
+                    raise AnsibleError(
+                        "Cannot write to ControlPath %s" % to_native(cpdir)
+                    )
 
-                self.control_path = self.get_option('control_path')
+                self.control_path = self.get_option("control_path")
                 if not self.control_path:
                     self.control_path = self._create_control_path(
-                        self.host,
-                        self.port,
-                        self.user
+                        self.host, self.port, self.user
                     )
-                b_args = (b"-o", b"ControlPath=" + to_bytes(self.control_path % dict(directory=cpdir), errors='surrogate_or_strict'))
-                self._add_args(b_command, b_args, u"found only ControlPersist; added ControlPath")
+                b_args = (
+                    b"-o",
+                    b"ControlPath="
+                    + to_bytes(
+                        self.control_path % dict(directory=cpdir),
+                        errors="surrogate_or_strict",
+                    ),
+                )
+                self._add_args(
+                    b_command, b_args, u"found only ControlPersist; added ControlPath"
+                )
 
         # Finally, we add any caller-supplied extras.
         if other_args:
@@ -694,64 +787,77 @@ class Connection(ConnectionBase):
         return b_command
 
     def _send_initial_data(self, fh, in_data):
-        '''
+        """
         Writes initial data to the stdin filehandle of the subprocess and closes
         it. (The handle must be closed; otherwise, for example, "sftp -b -" will
         just hang forever waiting for more commands.)
-        '''
+        """
 
-        display.debug('Sending initial data')
+        display.debug("Sending initial data")
 
         try:
             fh.write(to_bytes(in_data))
             fh.close()
         except (OSError, IOError):
-            raise AnsibleConnectionFailure('SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh' % self.host)
+            raise AnsibleConnectionFailure(
+                'SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh'
+                % self.host
+            )
 
-        display.debug('Sent initial data (%d bytes)' % len(in_data))
-
+        display.debug("Sent initial data (%d bytes)" % len(in_data))
 
     # Used by _run() to kill processes on failures
     @staticmethod
     def _terminate_process(p):
-        """ Terminate a process, ignoring errors """
+        """Terminate a process, ignoring errors"""
         try:
             p.terminate()
         except (OSError, IOError):
             pass
 
-
     # This is separate from _run() because we need to do the same thing for stdout
     # and stderr.
     def _examine_output(self, source, state, b_chunk, sudoable):
-        '''
+        """
         Takes a string, extracts complete lines from it, tests to see if they
         are a prompt, error message, etc., and sets appropriate flags in self.
         Prompt and success lines are removed.
         Returns the processed (i.e. possibly-edited) output and the unprocessed
         remainder (to be processed with the next chunk) as strings.
-        '''
+        """
 
         output = []
         for b_line in b_chunk.splitlines(True):
-            display_line = to_text(b_line).rstrip('\r\n')
+            display_line = to_text(b_line).rstrip("\r\n")
             suppress_output = False
 
             # display.debug("Examining line (source=%s, state=%s): '%s'" % (source, state, display_line))
             if self._play_context.prompt and self.check_password_prompt(b_line):
-                display.debug("become_prompt: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_prompt'] = True
+                display.debug(
+                    "become_prompt: (source=%s, state=%s): '%s'"
+                    % (source, state, display_line)
+                )
+                self._flags["become_prompt"] = True
                 suppress_output = True
             elif self._play_context.success_key and self.check_become_success(b_line):
-                display.debug("become_success: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_success'] = True
+                display.debug(
+                    "become_success: (source=%s, state=%s): '%s'"
+                    % (source, state, display_line)
+                )
+                self._flags["become_success"] = True
                 suppress_output = True
             elif sudoable and self.check_incorrect_password(b_line):
-                display.debug("become_error: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_error'] = True
+                display.debug(
+                    "become_error: (source=%s, state=%s): '%s'"
+                    % (source, state, display_line)
+                )
+                self._flags["become_error"] = True
             elif sudoable and self.check_missing_password(b_line):
-                display.debug("become_nopasswd_error: (source=%s, state=%s): '%s'" % (source, state, display_line))
-                self._flags['become_nopasswd_error'] = True
+                display.debug(
+                    "become_nopasswd_error: (source=%s, state=%s): '%s'"
+                    % (source, state, display_line)
+                )
+                self._flags["become_nopasswd_error"] = True
 
             if not suppress_output:
                 output.append(b_line)
@@ -761,22 +867,21 @@ class Connection(ConnectionBase):
         # have removed from the output), we retain it to be processed with the
         # next chunk.
 
-        remainder = b''
-        if output and not output[-1].endswith(b'\n'):
+        remainder = b""
+        if output and not output[-1].endswith(b"\n"):
             remainder = output[-1]
             output = output[:-1]
 
-        return b''.join(output), remainder
-
+        return b"".join(output), remainder
 
     # only used from Ansible version 2.3 on forward
     def _bare_run(self, cmd, in_data, sudoable=True, checkrc=True):
-        '''
+        """
         Starts the command and communicates with it until it ends.
-        '''
+        """
 
         display_cmd = list(map(shlex_quote, map(to_text, cmd)))
-        display.vvv(u'SSH: EXEC {0}'.format(u' '.join(display_cmd)), host=self.host)
+        display.vvv(u"SSH: EXEC {0}".format(u" ".join(display_cmd)), host=self.host)
 
         # Start the given command. If we don't need to pipeline data, we can try
         # to use a pseudo-tty (ssh will have been invoked with -tt). If we are
@@ -798,19 +903,38 @@ class Connection(ConnectionBase):
                 # Make sure stdin is a proper pty to avoid tcgetattr errors
                 master, slave = pty.openpty()
                 if PY3 and self._play_context.password:
-                    p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
+                    p = subprocess.Popen(
+                        cmd,
+                        stdin=slave,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        pass_fds=self.sshpass_pipe,
+                    )
                 else:
-                    p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                stdin = os.fdopen(master, 'wb', 0)
+                    p = subprocess.Popen(
+                        cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    )
+                stdin = os.fdopen(master, "wb", 0)
                 os.close(slave)
             except (OSError, IOError):
                 p = None
 
         if not p:
             if PY3 and self._play_context.password:
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
+                p = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    pass_fds=self.sshpass_pipe,
+                )
             else:
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                p = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
             stdin = p.stdin
 
         # If we are using SSH password authentication, write the password into
@@ -819,7 +943,9 @@ class Connection(ConnectionBase):
         if self._play_context.password:
             os.close(self.sshpass_pipe[0])
             try:
-                os.write(self.sshpass_pipe[1], to_bytes(self._play_context.password) + b'\n')
+                os.write(
+                    self.sshpass_pipe[1], to_bytes(self._play_context.password) + b"\n"
+                )
             except OSError as e:
                 # Ignore broken pipe errors if the sshpass process has exited.
                 if e.errno != errno.EPIPE or p.poll() is None:
@@ -835,25 +961,34 @@ class Connection(ConnectionBase):
         # escalation password and/or pipelined input to the process.
 
         states = [
-            'awaiting_prompt', 'awaiting_escalation', 'ready_to_send', 'awaiting_exit'
+            "awaiting_prompt",
+            "awaiting_escalation",
+            "ready_to_send",
+            "awaiting_exit",
         ]
 
         # Are we requesting privilege escalation? Right now, we may be invoked
         # to execute sftp/scp with sudoable=True, but we can request escalation
         # only when using ssh. Otherwise we can send initial data straightaway.
 
-        state = states.index('ready_to_send')
-        if b'ssh' in cmd:
+        state = states.index("ready_to_send")
+        if b"ssh" in cmd:
             if self._play_context.prompt:
                 # We're requesting escalation with a password, so we have to
                 # wait for a password prompt.
-                state = states.index('awaiting_prompt')
-                display.debug(u'Initial state: %s: %s' % (states[state], self._play_context.prompt))
+                state = states.index("awaiting_prompt")
+                display.debug(
+                    u"Initial state: %s: %s"
+                    % (states[state], self._play_context.prompt)
+                )
             elif self._play_context.become and self._play_context.success_key:
                 # We're requesting escalation without a password, so we have to
                 # detect success/failure before sending any initial data.
-                state = states.index('awaiting_escalation')
-                display.debug(u'Initial state: %s: %s' % (states[state], self._play_context.success_key))
+                state = states.index("awaiting_escalation")
+                display.debug(
+                    u"Initial state: %s: %s"
+                    % (states[state], self._play_context.success_key)
+                )
 
         # We store accumulated stdout and stderr output from the process here,
         # but strip any privilege escalation prompt/confirmation lines first.
@@ -861,12 +996,14 @@ class Connection(ConnectionBase):
         # an array, then checked and removed or copied to stdout or stderr. We
         # set any flags based on examining the output in self._flags.
 
-        b_stdout = b_stderr = b''
-        b_tmp_stdout = b_tmp_stderr = b''
+        b_stdout = b_stderr = b""
+        b_tmp_stdout = b_tmp_stderr = b""
 
         self._flags = dict(
-            become_prompt=False, become_success=False,
-            become_error=False, become_nopasswd_error=False
+            become_prompt=False,
+            become_success=False,
+            become_error=False,
+            become_nopasswd_error=False,
         )
 
         # select timeout should be longer than the connect timeout, otherwise
@@ -874,7 +1011,9 @@ class Connection(ConnectionBase):
         # timeout usually fails
         timeout = 2 + self._play_context.timeout
         for fd in (p.stdout, p.stderr):
-            fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+            fcntl.fcntl(
+                fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK
+            )
 
         # TODO: bcoca would like to use SelectSelector() when open
         # filehandles is low, then switch to more efficient ones when higher.
@@ -885,7 +1024,7 @@ class Connection(ConnectionBase):
 
         # If we can send initial data without waiting for anything, we do so
         # before we start polling
-        if states[state] == 'ready_to_send' and in_data:
+        if states[state] == "ready_to_send" and in_data:
             self._send_initial_data(stdin, in_data)
             state += 1
 
@@ -898,13 +1037,16 @@ class Connection(ConnectionBase):
 
                 if not events:
                     # We timed out
-                    if state <= states.index('awaiting_escalation'):
+                    if state <= states.index("awaiting_escalation"):
                         # If the process has already exited, then it's not really a
                         # timeout; we'll let the normal error handling deal with it.
                         if poll is not None:
                             break
                         self._terminate_process(p)
-                        raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, to_native(b_stdout)))
+                        raise AnsibleError(
+                            "Timeout (%ds) waiting for privilege escalation prompt: %s"
+                            % (timeout, to_native(b_stdout))
+                        )
 
                 # Read whatever output is available on stdout and stderr, and stop
                 # listening to the pipe if it's been closed.
@@ -912,7 +1054,7 @@ class Connection(ConnectionBase):
                 for key, event in events:
                     if key.fileobj == p.stdout:
                         b_chunk = p.stdout.read()
-                        if b_chunk == b'':
+                        if b_chunk == b"":
                             # stdout has been closed, stop watching it
                             selector.unregister(p.stdout)
                             # When ssh has ControlMaster (+ControlPath/Persist) enabled, the
@@ -924,78 +1066,94 @@ class Connection(ConnectionBase):
                             # not going to arrive until the persisted connection closes.
                             timeout = 1
                         b_tmp_stdout += b_chunk
-                        display.debug("stdout chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
+                        display.debug(
+                            "stdout chunk (state=%s):\n>>>%s<<<\n"
+                            % (state, to_text(b_chunk))
+                        )
                     elif key.fileobj == p.stderr:
                         b_chunk = p.stderr.read()
-                        if b_chunk == b'':
+                        if b_chunk == b"":
                             # stderr has been closed, stop watching it
                             selector.unregister(p.stderr)
                         b_tmp_stderr += b_chunk
-                        display.debug("stderr chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
+                        display.debug(
+                            "stderr chunk (state=%s):\n>>>%s<<<\n"
+                            % (state, to_text(b_chunk))
+                        )
 
                 # We examine the output line-by-line until we have negotiated any
                 # privilege escalation prompt and subsequent success/error message.
                 # Afterwards, we can accumulate output without looking at it.
 
-                if state < states.index('ready_to_send'):
+                if state < states.index("ready_to_send"):
                     if b_tmp_stdout:
-                        b_output, b_unprocessed = self._examine_output('stdout', states[state], b_tmp_stdout, sudoable)
+                        b_output, b_unprocessed = self._examine_output(
+                            "stdout", states[state], b_tmp_stdout, sudoable
+                        )
                         b_stdout += b_output
                         b_tmp_stdout = b_unprocessed
 
                     if b_tmp_stderr:
-                        b_output, b_unprocessed = self._examine_output('stderr', states[state], b_tmp_stderr, sudoable)
+                        b_output, b_unprocessed = self._examine_output(
+                            "stderr", states[state], b_tmp_stderr, sudoable
+                        )
                         b_stderr += b_output
                         b_tmp_stderr = b_unprocessed
                 else:
                     b_stdout += b_tmp_stdout
                     b_stderr += b_tmp_stderr
-                    b_tmp_stdout = b_tmp_stderr = b''
+                    b_tmp_stdout = b_tmp_stderr = b""
 
                 # If we see a privilege escalation prompt, we send the password.
                 # (If we're expecting a prompt but the escalation succeeds, we
                 # didn't need the password and can carry on regardless.)
 
-                if states[state] == 'awaiting_prompt':
-                    if self._flags['become_prompt']:
-                        display.debug('Sending become_pass in response to prompt')
-                        stdin.write(to_bytes(self._play_context.become_pass) + b'\n')
-                        self._flags['become_prompt'] = False
+                if states[state] == "awaiting_prompt":
+                    if self._flags["become_prompt"]:
+                        display.debug("Sending become_pass in response to prompt")
+                        stdin.write(to_bytes(self._play_context.become_pass) + b"\n")
+                        self._flags["become_prompt"] = False
                         state += 1
-                    elif self._flags['become_success']:
+                    elif self._flags["become_success"]:
                         state += 1
 
                 # We've requested escalation (with or without a password), now we
                 # wait for an error message or a successful escalation.
 
-                if states[state] == 'awaiting_escalation':
-                    if self._flags['become_success']:
-                        display.debug('Escalation succeeded')
-                        self._flags['become_success'] = False
+                if states[state] == "awaiting_escalation":
+                    if self._flags["become_success"]:
+                        display.debug("Escalation succeeded")
+                        self._flags["become_success"] = False
                         state += 1
-                    elif self._flags['become_error']:
-                        display.debug('Escalation failed')
+                    elif self._flags["become_error"]:
+                        display.debug("Escalation failed")
                         self._terminate_process(p)
-                        self._flags['become_error'] = False
-                        raise AnsibleError('Incorrect %s password' % self._play_context.become_method)
-                    elif self._flags['become_nopasswd_error']:
-                        display.debug('Escalation requires password')
+                        self._flags["become_error"] = False
+                        raise AnsibleError(
+                            "Incorrect %s password" % self._play_context.become_method
+                        )
+                    elif self._flags["become_nopasswd_error"]:
+                        display.debug("Escalation requires password")
                         self._terminate_process(p)
-                        self._flags['become_nopasswd_error'] = False
-                        raise AnsibleError('Missing %s password' % self._play_context.become_method)
-                    elif self._flags['become_prompt']:
+                        self._flags["become_nopasswd_error"] = False
+                        raise AnsibleError(
+                            "Missing %s password" % self._play_context.become_method
+                        )
+                    elif self._flags["become_prompt"]:
                         # This shouldn't happen, because we should see the "Sorry,
                         # try again" message first.
-                        display.debug('Escalation prompt repeated')
+                        display.debug("Escalation prompt repeated")
                         self._terminate_process(p)
-                        self._flags['become_prompt'] = False
-                        raise AnsibleError('Incorrect %s password' % self._play_context.become_method)
+                        self._flags["become_prompt"] = False
+                        raise AnsibleError(
+                            "Incorrect %s password" % self._play_context.become_method
+                        )
 
                 # Once we're sure that the privilege escalation prompt, if any, has
                 # been dealt with, we can send any initial data and start waiting
                 # for output.
 
-                if states[state] == 'ready_to_send':
+                if states[state] == "ready_to_send":
                     if in_data:
                         self._send_initial_data(stdin, in_data)
                     state += 1
@@ -1027,59 +1185,74 @@ class Connection(ConnectionBase):
             # completely (see also issue #848)
             stdin.close()
 
-        if self.get_option('host_key_checking'):
+        if self.get_option("host_key_checking"):
             if cmd[0] == b"sshpass" and p.returncode == 6:
-                raise AnsibleError('Using a SSH password instead of a key is not possible because Host Key checking is enabled and sshpass does not support '
-                                   'this.  Please add this host\'s fingerprint to your known_hosts file to manage this host.')
+                raise AnsibleError(
+                    "Using a SSH password instead of a key is not possible because Host Key checking is enabled and sshpass does not support "
+                    "this.  Please add this host's fingerprint to your known_hosts file to manage this host."
+                )
 
-        controlpersisterror = b'Bad configuration option: ControlPersist' in b_stderr or b'unknown configuration option: ControlPersist' in b_stderr
+        controlpersisterror = (
+            b"Bad configuration option: ControlPersist" in b_stderr
+            or b"unknown configuration option: ControlPersist" in b_stderr
+        )
         if p.returncode != 0 and controlpersisterror:
-            raise AnsibleError('using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" '
-                               '(or ssh_args in [ssh_connection] section of the config file) before running again')
+            raise AnsibleError(
+                'using -c ssh on certain older ssh versions may not support ControlPersist, set ANSIBLE_SSH_ARGS="" '
+                "(or ssh_args in [ssh_connection] section of the config file) before running again"
+            )
 
         # If we find a broken pipe because of ControlPersist timeout expiring (see #16731),
         # we raise a special exception so that we can retry a connection.
-        controlpersist_broken_pipe = b'mux_client_hello_exchange: write packet: Broken pipe' in b_stderr
+        controlpersist_broken_pipe = (
+            b"mux_client_hello_exchange: write packet: Broken pipe" in b_stderr
+        )
         if p.returncode == 255 and controlpersist_broken_pipe:
-            raise AnsibleControlPersistBrokenPipeError('SSH Error: data could not be sent because of ControlPersist broken pipe.')
+            raise AnsibleControlPersistBrokenPipeError(
+                "SSH Error: data could not be sent because of ControlPersist broken pipe."
+            )
 
         if p.returncode == 255 and in_data and checkrc:
-            raise AnsibleConnectionFailure('SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh' % self.host)
+            raise AnsibleConnectionFailure(
+                'SSH Error: data could not be sent to remote host "%s". Make sure this host can be reached over ssh'
+                % self.host
+            )
 
         return (p.returncode, b_stdout, b_stderr)
 
-
     @_ssh_retry
     def _run(self, cmd, in_data, sudoable=True, checkrc=True):
-        """Wrapper around _bare_run that retries the connection
-        """
+        """Wrapper around _bare_run that retries the connection"""
         return self._bare_run(cmd, in_data, sudoable, checkrc)
 
-
     def _exec_command(self, cmd, in_data=None, sudoable=True):
-        ''' run a command on the remote host '''
+        """run a command on the remote host"""
 
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
+        display.vvv(
+            u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(
+                self._play_context.remote_user
+            ),
+            host=self._play_context.remote_addr,
+        )
 
         # we can only use tty when we are not pipelining the modules. piping
         # data into /usr/bin/python inside a tty automatically invokes the
         # python interactive-mode but the modules are not compatible with the
         # interactive-mode ("unexpected indent" mainly because of empty lines)
 
-        ssh_executable = self.get_option('ssh_executable')
+        ssh_executable = self.get_option("ssh_executable")
         if in_data:
-            cmd = self._build_command(ssh_executable, 'ssh', self.host, cmd)
+            cmd = self._build_command(ssh_executable, "ssh", self.host, cmd)
         else:
-            cmd = self._build_command(ssh_executable, 'ssh', '-tt', self.host, cmd)
+            cmd = self._build_command(ssh_executable, "ssh", "-tt", self.host, cmd)
 
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
 
         return (returncode, stdout, stderr)
 
-
-    def dir_print(self,obj):
+    def dir_print(self, obj):
         for attr_name in dir(obj):
             try:
                 attr_value = getattr(obj, attr_name)
@@ -1087,153 +1260,173 @@ class Connection(ConnectionBase):
             except:
                 pass
 
-
     #
     # Main public methods
     #
     def exec_command(self, cmd, in_data=None, sudoable=False):
-        ''' run a command on the chroot '''
-        display.vvv('XXX exec_command: %s' % cmd)
+        """run a command on the chroot"""
+        display.vvv("XXX exec_command: %s" % cmd)
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        ssh_executable = self.get_option('ssh_executable')
+        ssh_executable = self.get_option("ssh_executable")
         ##print(dir(self))
         ##print dir(self._play_context)
         ##print self._play_context._attributes
-        #self.dir_print(self._play_context)
-        #vm = self._play_context.get_ds()
-        #print( vm )
-        #raise "blah"
+        # self.dir_print(self._play_context)
+        # vm = self._play_context.get_ds()
+        # print( vm )
+        # raise "blah"
         h = self.container_name
-        if (self.lxc_version == 2):
-            lxc_cmd = 'lxc exec %s --mode=non-interactive -- /bin/sh -c %s'  \
-                    % (pipes.quote(h),
-                       pipes.quote(cmd))
-        elif (self.lxc_version == 1):
-            lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
-                    % (pipes.quote(h),
-                       pipes.quote(cmd))
+        if self.lxc_version == 2:
+            lxc_cmd = "lxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
+                pipes.quote(h),
+                pipes.quote(cmd),
+            )
+        elif self.lxc_version == 1:
+            lxc_cmd = "lxc-attach --name %s -- /bin/sh -c %s" % (
+                pipes.quote(h),
+                pipes.quote(cmd),
+            )
         if in_data:
-            cmd = self._build_command(ssh_executable, 'ssh', self.host, lxc_cmd)
+            cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
         else:
-            cmd = self._build_command(ssh_executable, 'ssh', '-tt', self.host, lxc_cmd)
-        #self.ssh.exec_command(lxc_cmd,in_data,sudoable)
+            cmd = self._build_command(ssh_executable, "ssh", "-tt", self.host, lxc_cmd)
+        # self.ssh.exec_command(lxc_cmd,in_data,sudoable)
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
         return (returncode, stdout, stderr)
 
-
     def put_file(self, in_path, out_path):
-        ''' transfer a file from local to lxc '''
+        """transfer a file from local to lxc"""
         super(Connection, self).put_file(in_path, out_path)
         display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self.host)
-        ssh_executable = self.get_option('ssh_executable')
+        ssh_executable = self.get_option("ssh_executable")
 
-        if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
-            raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_native(in_path)))
+        if not os.path.exists(to_bytes(in_path, errors="surrogate_or_strict")):
+            raise AnsibleFileNotFound(
+                "file or module does not exist: {0}".format(to_native(in_path))
+            )
 
         if sys.version_info[0] >= 3:
-            with open(in_path,'rb') as in_f:
+            with open(in_path, "rb") as in_f:
                 in_data = in_f.read()
-                if (len(in_data) == 0):
+                if len(in_data) == 0:
                     # define a shortcut for empty files - nothing ro read so the ssh pipe will hang
-                    cmd = ('touch %s; echo -n done' % pipes.quote(out_path))
+                    cmd = "touch %s; echo -n done" % pipes.quote(out_path)
                 else:
                     # regular command
-                    cmd = ('cat > %s; echo -n done' % pipes.quote(out_path))
+                    cmd = "cat > %s; echo -n done" % pipes.quote(out_path)
                 h = self.container_name
-                if (self.lxc_version == 2):
-                    lxc_cmd = 'lxc exec %s --mode=non-interactive -- /bin/sh -c %s'  \
-                            % (pipes.quote(h),
-                               pipes.quote(cmd))
-                elif (self.lxc_version == 1):
-                    lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
-                            % (pipes.quote(h),
-                               pipes.quote(cmd))
+                if self.lxc_version == 2:
+                    lxc_cmd = "lxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
+                        pipes.quote(h),
+                        pipes.quote(cmd),
+                    )
+                elif self.lxc_version == 1:
+                    lxc_cmd = "lxc-attach --name %s -- /bin/sh -c %s" % (
+                        pipes.quote(h),
+                        pipes.quote(cmd),
+                    )
                 if in_data:
-                    cmd = self._build_command(ssh_executable, 'ssh', self.host, lxc_cmd)
+                    cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
                 else:
-                    cmd = self._build_command(ssh_executable, 'ssh', '-tt', self.host, lxc_cmd)
-                #self.ssh.exec_command(lxc_cmd,in_data,sudoable)
+                    cmd = self._build_command(
+                        ssh_executable, "ssh", "-tt", self.host, lxc_cmd
+                    )
+                # self.ssh.exec_command(lxc_cmd,in_data,sudoable)
                 (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=False)
                 return (returncode, stdout, stderr)
         else:
-            with open(in_path,'r') as in_f:
+            with open(in_path, "r") as in_f:
                 in_data = in_f.read()
-                if (len(in_data) == 0):
+                if len(in_data) == 0:
                     # define a shortcut for empty files - nothing ro read so the ssh pipe will hang
-                    cmd = ('touch %s; echo -n done' % pipes.quote(out_path))
+                    cmd = "touch %s; echo -n done" % pipes.quote(out_path)
                 else:
                     # regular command
-                    cmd = ('cat > %s; echo -n done' % pipes.quote(out_path))
+                    cmd = "cat > %s; echo -n done" % pipes.quote(out_path)
                 h = self.container_name
-                if (self.lxc_version == 2):
-                    lxc_cmd = 'lxc exec %s --mode=non-interactive -- /bin/sh -c %s'  \
-                            % (pipes.quote(h),
-                               pipes.quote(cmd))
-                elif (self.lxc_version == 1):
-                    lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
-                            % (pipes.quote(h),
-                               pipes.quote(cmd))
+                if self.lxc_version == 2:
+                    lxc_cmd = "lxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
+                        pipes.quote(h),
+                        pipes.quote(cmd),
+                    )
+                elif self.lxc_version == 1:
+                    lxc_cmd = "lxc-attach --name %s -- /bin/sh -c %s" % (
+                        pipes.quote(h),
+                        pipes.quote(cmd),
+                    )
                 if in_data:
-                    cmd = self._build_command(ssh_executable, 'ssh', self.host, lxc_cmd)
+                    cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
                 else:
-                    cmd = self._build_command(ssh_executable, 'ssh', '-tt', self.host, lxc_cmd)
-                #self.ssh.exec_command(lxc_cmd,in_data,sudoable)
+                    cmd = self._build_command(
+                        ssh_executable, "ssh", "-tt", self.host, lxc_cmd
+                    )
+                # self.ssh.exec_command(lxc_cmd,in_data,sudoable)
                 (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=False)
                 return (returncode, stdout, stderr)
 
-
     def fetch_file(self, in_path, out_path):
-        ''' fetch a file from lxc to local '''
+        """fetch a file from lxc to local"""
         super(Connection, self).fetch_file(in_path, out_path)
         display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
-        ssh_executable = self.get_option('ssh_executable')
+        ssh_executable = self.get_option("ssh_executable")
 
-        cmd = ('cat < %s' % pipes.quote(in_path))
+        cmd = "cat < %s" % pipes.quote(in_path)
         h = self.container_name
-        if (self.lxc_version == 2):
-            lxc_cmd = 'lxc exec %s --mode=non-interactive -- /bin/sh -c %s'  \
-                    % (pipes.quote(h),
-                       pipes.quote(cmd))
-        elif (self.lxc_version == 1):
-            lxc_cmd = 'lxc-attach --name %s -- /bin/sh -c %s'  \
-                    % (pipes.quote(h),
-                       pipes.quote(cmd))
+        if self.lxc_version == 2:
+            lxc_cmd = "lxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
+                pipes.quote(h),
+                pipes.quote(cmd),
+            )
+        elif self.lxc_version == 1:
+            lxc_cmd = "lxc-attach --name %s -- /bin/sh -c %s" % (
+                pipes.quote(h),
+                pipes.quote(cmd),
+            )
 
-        cmd = self._build_command(ssh_executable, 'ssh', self.host, lxc_cmd)
+        cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
         (returncode, stdout, stderr) = self._run(cmd, None, sudoable=False)
 
         if returncode != 0:
-            raise AnsibleError("failed to transfer file from {0}:\n{1}\n{2}".format(in_path, stdout, stderr))
+            raise AnsibleError(
+                "failed to transfer file from {0}:\n{1}\n{2}".format(
+                    in_path, stdout, stderr
+                )
+            )
 
         if sys.version_info[0] >= 3:
-            with open(out_path,'wb') as out_f:
+            with open(out_path, "wb") as out_f:
                 out_f.write(stdout)
         else:
-            with open(out_path,'w') as out_f:
+            with open(out_path, "w") as out_f:
                 out_f.write(stdout)
 
         return (returncode, stdout, stderr)
-
 
     # only used from Ansible version 2.3 on forward
     def reset(self):
         # If we have a persistent ssh connection (ControlPersist), we can ask it to stop listening.
-        cmd = self._build_command(self.get_option('ssh_executable'), 'ssh', '-O', 'stop', self.host)
+        cmd = self._build_command(
+            self.get_option("ssh_executable"), "ssh", "-O", "stop", self.host
+        )
         controlpersist, controlpath = self._persistence_controls(cmd)
         if controlpersist:
-            display.vvv(u'sending stop: %s' % cmd)
-            p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            display.vvv(u"sending stop: %s" % cmd)
+            p = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             stdout, stderr = p.communicate()
             status_code = p.wait()
             if status_code != 0:
                 raise AnsibleError("Cannot reset connection:\n%s" % stderr)
         self.close()
 
-
     def close(self):
-        ''' terminate the connection; nothing to do here '''
-        display.vvv('XXX close')
+        """terminate the connection; nothing to do here"""
+        display.vvv("XXX close")
         super(Connection, self).close()
-        #self.ssh.close()
+        # self.ssh.close()
         self._connected = False


### PR DESCRIPTION
The [debops](https://docs.debops.org/en/master/) project uses your connection plugin for their debops.lxc ansible role.

We saw the PR https://github.com/andreasscherbaum/ansible-lxc-ssh/pull/31 and plan to port the resulting new plugin over to debops.

The main dev of debops told me to make the plugin PEP8-compatible, so I ran it through a PEP8-compliant formatter.

I know of the rejected PR https://github.com/andreasscherbaum/ansible-lxc-ssh/pull/15, and we fully understand the priority of readability for the coder. Pls review if the suggested changes work for you. To me the diff looks as if it just fixes/changes some formatting, but doesn't move stuff around.

Regards, Stefan