### PR TITLE
Define _sshpass_available (fixes #46)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,9 @@ jobs:
         run: echo "::set-output name=IF::$(sudo lxc exec test-container -- ip -4 -o link show | awk '{print $2}' | cut -f1 -d':' | cut -f1 -d'@' | grep '^e[tn]')"
         id: test_container_interface
 
+      - name: Request and wait for IPv4 address
+        run: sudo lxc exec test-container -- dhclient -v ${{ steps.test_container_interface.outputs.IF }}
+
       - name: Store Container IPv4 address
         run: echo "::set-output name=IPv4::$(sudo lxc exec test-container -- ip -o -4 addr show ${{ steps.test_container_interface.outputs.IF }} | awk '{print $4}' | cut -d/ -f1)"
         id: test_container_ipv4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,17 @@ jobs:
         run: sudo lxc exec test-container -- chown -R ubuntu. /home/ubuntu/.ssh
 
 
+      # configure password & other requirements for password authentication
+      - name: Set root user password in container
+        run: sudo lxc exec test-container -- sh -c 'printf "password\npassword\n" | passwd'
+
+      - name: Set ubuntu user password in container
+        run: sudo lxc exec test-container -- sh -c 'printf "password\npassword\n" | passwd ubuntu'
+
+      - name: Install sshpass on runner
+        run: sudo apt-get -y install sshpass
+
+
       # update known_hosts for root
       - name: Create /root/.ssh/known_hosts
         run: sudo touch /root/.ssh/known_hosts
@@ -236,6 +247,9 @@ jobs:
 
       - name: Test ssh connection from runner into ubuntu user
         run: ssh -i $HOME/.ssh/id_ed25519 -o PreferredAuthentications=publickey -o PasswordAuthentication=no -l ubuntu ${{ steps.test_container_ipv4.outputs.IPv4 }} uptime
+
+      - name: Test ssh connection into root user with password authentication
+        run: sshpass -p 'password' ssh -i /dev/null -l ubuntu ${{ steps.test_container_ipv4.outputs.IPv4 }} uptime
 
 
       # copy logfiles from container into log
@@ -325,3 +339,23 @@ jobs:
 
       - name: Run test
         run: ANSIBLE_CONFIG=$GITHUB_WORKSPACE/tests/ cd tests && ansible-playbook -i $GITHUB_WORKSPACE/tests/inventory.yml $GITHUB_WORKSPACE/tests/test-lxc_ssh.yml
+
+      # Test password authentication
+      - name: Add a password for the SSH connection
+        run: >
+          printf '      ansible_ssh_pass: "password"\n      ansible_ssh_private_key_file: "/dev/null"' >> $GITHUB_WORKSPACE/tests/inventory.yml
+
+      - name: Run test with password
+        run: >
+          ANSIBLE_CONFIG=$GITHUB_WORKSPACE/tests/ cd tests && ansible-playbook -i $GITHUB_WORKSPACE/tests/inventory.yml $GITHUB_WORKSPACE/tests/test-lxc_ssh.yml -t short
+
+      - name: Remove sshpass
+        run: sudo apt-get remove -y sshpass
+
+      - name: Run test with password and without sshpass (expect command failure)
+        run: >
+          set +e;
+          stdout=$(ANSIBLE_CONFIG=$GITHUB_WORKSPACE/tests/ cd tests && ansible-playbook -i $GITHUB_WORKSPACE/tests/inventory.yml $GITHUB_WORKSPACE/tests/test-lxc_ssh.yml -t short);
+          status=$?;
+          set -e;
+          [ $status -eq 2 ] && echo "$stdout" | grep -F "to use the 'ssh' connection type with passwords,  you must install the sshpass program"

--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -482,7 +482,7 @@ def _ssh_retry(func):
                 if attempt == remaining_tries - 1:
                     raise
                 else:
-                    pause = 2 ** attempt - 1
+                    pause = 2**attempt - 1
                     if pause > 30:
                         pause = 30
 
@@ -738,7 +738,7 @@ class Connection(ConnectionBase):
                 to_bytes(a, errors="surrogate_or_strict")
                 for a in self._split_ssh_args(ssh_args)
             ]
-            self._add_args(b_command, b_args, u"ansible.cfg set ssh_args")
+            self._add_args(b_command, b_args, "ansible.cfg set ssh_args")
 
         # Now we add various arguments that have their own specific settings
         # defined in docs above.

--- a/tests/test-lxc_ssh.yml
+++ b/tests/test-lxc_ssh.yml
@@ -35,8 +35,10 @@
         filename: "test_50mb"
 
     - name: Test command
+      tags: [short]
       include_tasks:
         file: "test-command.yml"
+        apply: { tags: [short] }
       vars:
         expect_user: "root"
 


### PR DESCRIPTION
See #46 

> That method was implemented in https://github.com/chifflier/ansible-lxc-ssh/pull/1/files#diff-d5708b826a77f4da31d0b14b8c7c491973a414658f496a9f2b687745c3b9a2c1R58-R75. A part of the PR was incorporated into this fork in 4e569a7, but the _sshpass_available method seems to be missing. Adding it together with the SSHPASS_AVAILABLE variable fixes the issue.