### PR TITLE
Convert imported option lxc_host to string.

### DIFF
--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -565,7 +565,7 @@ class Connection(ConnectionBase):
         """connect to the lxc; nothing to do here"""
         display.vvv("XXX connect")
         super(Connection, self)._connect()
-        self.container_name = self.get_option("lxc_host")
+        self.container_name = str(self.get_option("lxc_host"))
 
     @staticmethod
     def _create_control_path(host, port, user, connection=None):


### PR DESCRIPTION
Hi, when executing against proxmox, lxc_host is always a number. Python interprets this as an integer and the module gives the following error:
`TypeError: expected string or bytes-like object`
Converting the variable self.container_name to str at import fixes this.

Thanks.