### PR TITLE
Replace deprecated `pipes` with `shlex` and drop Python 2 support

### DIFF
--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -630,18 +630,11 @@ class Connection(ConnectionBase):
         list ['-o', 'Foo=1', '-o', 'Bar=foo bar'] that can be added to
         the argument list. The list will not contain any empty elements.
         """
-        if sys.version_info[0] >= 3:
-            return [
-                to_unicode(x.strip())
-                for x in shlex.split(to_bytes(argstring).decode())
-                if x.strip()
-            ]
-        else:
-            return [
-                to_unicode(x.strip())
-                for x in shlex.split(to_bytes(argstring))
-                if x.strip()
-            ]
+        return [
+            to_unicode(x.strip())
+            for x in shlex.split(to_bytes(argstring).decode())
+            if x.strip()
+        ]
 
     def _add_args(self, b_command, b_args, explanation):
         """
@@ -989,10 +982,7 @@ class Connection(ConnectionBase):
         if isinstance(cmd, (text_type, binary_type)):
             cmd = to_bytes(cmd)
         else:
-            if sys.version_info[0] >= 3:
-                cmd = list(map(to_bytes, cmd))
-            else:
-                cmd = map(to_bytes, cmd)
+            cmd = list(map(to_bytes, cmd))
 
         if not in_data:
             try:
@@ -1413,68 +1403,37 @@ class Connection(ConnectionBase):
                 "file or module does not exist: {0}".format(to_native(in_path))
             )
 
-        if sys.version_info[0] >= 3:
-            with open(in_path, "rb") as in_f:
-                in_data = in_f.read()
-                if len(in_data) == 0:
-                    # define a shortcut for empty files - nothing ro read so
-                    # the ssh pipe will hang
-                    cmd = "touch %s; echo -n done" % shlex.quote(out_path)
-                else:
-                    # regular command
-                    cmd = "cat > %s; echo -n done" % shlex.quote(out_path)
-                h = self.container_name
-                if self.lxc_version == 2:
-                    lxc_cmd = "%slxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
-                        self.systemd_run_prefix,
-                        shlex.quote(h),
-                        shlex.quote(cmd),
-                    )
-                elif self.lxc_version == 1:
-                    lxc_cmd = "%slxc-attach --name %s -- /bin/sh -c %s" % (
-                        self.systemd_run_prefix,
-                        shlex.quote(h),
-                        shlex.quote(cmd),
-                    )
-                if in_data:
-                    cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
-                else:
-                    cmd = self._build_command(
-                        ssh_executable, "ssh", "-tt", self.host, lxc_cmd
-                    )
-                (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=False)
-                return (returncode, stdout, stderr)
-        else:
-            with open(in_path, "r") as in_f:
-                in_data = in_f.read()
-                if len(in_data) == 0:
-                    # define a shortcut for empty files - nothing ro read so
-                    # the ssh pipe will hang
-                    cmd = "touch %s; echo -n done" % pipes.quote(out_path)
-                else:
-                    # regular command
-                    cmd = "cat > %s; echo -n done" % pipes.quote(out_path)
-                h = self.container_name
-                if self.lxc_version == 2:
-                    lxc_cmd = "%slxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
-                        self.systemd_run_prefix,
-                        pipes.quote(h),
-                        pipes.quote(cmd),
-                    )
-                elif self.lxc_version == 1:
-                    lxc_cmd = "%slxc-attach --name %s -- /bin/sh -c %s" % (
-                        self.systemd_run_prefix,
-                        pipes.quote(h),
-                        pipes.quote(cmd),
-                    )
-                if in_data:
-                    cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
-                else:
-                    cmd = self._build_command(
-                        ssh_executable, "ssh", "-tt", self.host, lxc_cmd
-                    )
-                (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=False)
-                return (returncode, stdout, stderr)
+        with open(in_path, "rb") as in_f:
+            in_data = in_f.read()
+            if len(in_data) == 0:
+                # define a shortcut for empty files - nothing ro read so
+                # the ssh pipe will hang
+                cmd = "touch %s; echo -n done" % shlex.quote(out_path)
+            else:
+                # regular command
+                cmd = "cat > %s; echo -n done" % shlex.quote(out_path)
+            h = self.container_name
+            if self.lxc_version == 2:
+                lxc_cmd = "%slxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
+                    self.systemd_run_prefix,
+                    shlex.quote(h),
+                    shlex.quote(cmd),
+                )
+            elif self.lxc_version == 1:
+                lxc_cmd = "%slxc-attach --name %s -- /bin/sh -c %s" % (
+                    self.systemd_run_prefix,
+                    shlex.quote(h),
+                    shlex.quote(cmd),
+                )
+            if in_data:
+                cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
+            else:
+                cmd = self._build_command(
+                    ssh_executable, "ssh", "-tt", self.host, lxc_cmd
+                )
+            (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=False)
+            return (returncode, stdout, stderr)
+
 
     def fetch_file(self, in_path, out_path):
         """fetch a file from lxc to local"""
@@ -1507,12 +1466,8 @@ class Connection(ConnectionBase):
                 )
             )
 
-        if sys.version_info[0] >= 3:
-            with open(out_path, "wb") as out_f:
-                out_f.write(stdout)
-        else:
-            with open(out_path, "w") as out_f:
-                out_f.write(stdout)
+        with open(out_path, "wb") as out_f:
+            out_f.write(stdout)
 
         return (returncode, stdout, stderr)
 

--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -28,7 +28,6 @@ import errno
 import fcntl
 import hashlib
 import os
-import pipes
 import pty
 import selectors
 import shlex
@@ -1387,14 +1386,14 @@ class Connection(ConnectionBase):
         if self.lxc_version == 2:
             lxc_cmd = "%slxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
                 self.systemd_run_prefix,
-                pipes.quote(h),
-                pipes.quote(cmd),
+                shlex.quote(h),
+                shlex.quote(cmd),
             )
         elif self.lxc_version == 1:
             lxc_cmd = "%slxc-attach --name %s -- /bin/sh -c %s" % (
                 self.systemd_run_prefix,
-                pipes.quote(h),
-                pipes.quote(cmd),
+                shlex.quote(h),
+                shlex.quote(cmd),
             )
         if in_data:
             cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
@@ -1420,22 +1419,22 @@ class Connection(ConnectionBase):
                 if len(in_data) == 0:
                     # define a shortcut for empty files - nothing ro read so
                     # the ssh pipe will hang
-                    cmd = "touch %s; echo -n done" % pipes.quote(out_path)
+                    cmd = "touch %s; echo -n done" % shlex.quote(out_path)
                 else:
                     # regular command
-                    cmd = "cat > %s; echo -n done" % pipes.quote(out_path)
+                    cmd = "cat > %s; echo -n done" % shlex.quote(out_path)
                 h = self.container_name
                 if self.lxc_version == 2:
                     lxc_cmd = "%slxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
                         self.systemd_run_prefix,
-                        pipes.quote(h),
-                        pipes.quote(cmd),
+                        shlex.quote(h),
+                        shlex.quote(cmd),
                     )
                 elif self.lxc_version == 1:
                     lxc_cmd = "%slxc-attach --name %s -- /bin/sh -c %s" % (
                         self.systemd_run_prefix,
-                        pipes.quote(h),
-                        pipes.quote(cmd),
+                        shlex.quote(h),
+                        shlex.quote(cmd),
                     )
                 if in_data:
                     cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)
@@ -1483,19 +1482,19 @@ class Connection(ConnectionBase):
         display.vvv("FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
         ssh_executable = self.get_option("ssh_executable")
 
-        cmd = "cat < %s" % pipes.quote(in_path)
+        cmd = "cat < %s" % shlex.quote(in_path)
         h = self.container_name
         if self.lxc_version == 2:
             lxc_cmd = "%slxc exec %s --mode=non-interactive -- /bin/sh -c %s" % (
                 self.systemd_run_prefix,
-                pipes.quote(h),
-                pipes.quote(cmd),
+                shlex.quote(h),
+                shlex.quote(cmd),
             )
         elif self.lxc_version == 1:
             lxc_cmd = "%slxc-attach --name %s -- /bin/sh -c %s" % (
                 self.systemd_run_prefix,
-                pipes.quote(h),
-                pipes.quote(cmd),
+                shlex.quote(h),
+                shlex.quote(cmd),
             )
 
         cmd = self._build_command(ssh_executable, "ssh", self.host, lxc_cmd)

--- a/lxc_ssh.py
+++ b/lxc_ssh.py
@@ -41,7 +41,6 @@ from ansible.errors import (
     AnsibleConnectionFailure,
     AnsibleFileNotFound,
 )
-from ansible.module_utils.six import PY3, text_type, binary_type
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.path import unfrackpath, makedirs_safe
@@ -969,7 +968,7 @@ class Connection(ConnectionBase):
 
         p = None
 
-        if isinstance(cmd, (text_type, binary_type)):
+        if isinstance(cmd, (str, bytes)):
             cmd = to_bytes(cmd)
         else:
             cmd = list(map(to_bytes, cmd))
@@ -978,7 +977,7 @@ class Connection(ConnectionBase):
             try:
                 # Make sure stdin is a proper pty to avoid tcgetattr errors
                 master, slave = pty.openpty()
-                if PY3 and self._play_context.password:
+                if self._play_context.password:
                     p = subprocess.Popen(
                         cmd,
                         stdin=slave,
@@ -999,7 +998,7 @@ class Connection(ConnectionBase):
                 p = None
 
         if not p:
-            if PY3 and self._play_context.password:
+            if self._play_context.password:
                 p = subprocess.Popen(
                     cmd,
                     stdin=subprocess.PIPE,


### PR DESCRIPTION
`pipes` was deprecated and got removed in 3.13. I tested that `shlex.quote` works in 3.9 (Debian 11) and even 3.6 (EL 8), so it shouldn't be a problem for most users.

I'm also dropping support for Python 2, but this part is optional.

CC @strk